### PR TITLE
Improved UX by showing all hex values by default

### DIFF
--- a/src/components/color-block.js
+++ b/src/components/color-block.js
@@ -24,11 +24,6 @@ const ColorBlockContainer = styled.div`
   flex-shrink: 1;
   cursor: pointer;
 
-  &:not(:hover) .ColorBlockCode {
-    opacity: 0;
-    transition: .6s;
-  }
-
   @media (max-width: 720px) {
     ${props => props.wide && 'min-width: 96px'};
   }


### PR DESCRIPTION
👋 @hihayk

I'm a Product Designer at AngelList and yesterday I was working to explore a few different color scales for our design system at AngelList and this tool is a huge time saver -- Thank you! Unfortunately, the feature of hiding the Hex codes with `opacity: 0` was frustrating, because I wanted to take screenshots that included all hex codes.

As a hack, I used a CSS injector extension to fix this, but I also want to propose making this change in the base repo, so that everyone can benefit from the transparency. 🤞

If you feel strongly about having a way to view the scale without the hex values, I recommend adding a switch to show/hide hex values -- however, that's beyond the scope of this PR.

Thanks, Hayk!

