### PR TITLE
Fix window crashing on repeated location change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -147,11 +147,11 @@ const ScaleApp = () => {
   }
 
   if(getHash()) {
-    window.location.hash = encodeURI(Object.values(getHash()).join('/'))
+      window.history.pushState({}, "", encodeURI("#" + Object.values(currentState).join("/")));
   }
 
   const updateHash = () => {
-    window.location.hash = encodeURI(Object.values(currentState).join('/'))
+    window.history.pushState({}, "", encodeURI("#" + Object.values(currentState).join("/")));
   }
   
   const updateThemeColor = () => {


### PR DESCRIPTION
The app was calling window.location.hash repeatedly on slider changes, causing the browser to crash the app due to too many location changes. 

This change fixes that problem by using window.history.pushState instead of window.location.hash, which rewrites the URL in the browser without telling it to actually do any location changes.